### PR TITLE
fix return NotFound

### DIFF
--- a/bootstrap/ContainerServices.php
+++ b/bootstrap/ContainerServices.php
@@ -366,7 +366,7 @@ class ContainerServices
     public function registerNotFoundHandler()
     {
         $this->registerService('notFoundHandler', function () {
-            return new App\Handler\NotFound($this->container, function ($request, $response) {
+            return new \App\Handler\NotFound($this->container, function ($request, $response) {
                 return $this->container['response']->withStatus(404);
             });
         });


### PR DESCRIPTION
estava com erro quando mandava a exceção pois faltava essa barra antes do 'App' senão ele tentava procurar no namespace do 'bootstrap'.